### PR TITLE
Path issue on RetroArch Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf ./dist || true
 
 ${LUTRO_DIST_PATH}: $(TRANSPILED) $(DIST_ASSETS)
-	cd dist && zip $@ $(patsubst dist/%, %, $^)
+	cd dist && zip -r $@ .
 
 package: ${LUTRO_DIST_PATH}
 


### PR DESCRIPTION
Not sure what your intention was of `$(patsubst dist/%, %, $^)`. The only difference I can see is that the `assets/` dir is not included in the zip, which leads to issues on RetroArch Mac.

The issue when `assets/` dir is **not** included:
```bash
➜  explodelon git:(main) ✗ /Applications/RetroArch.app/Contents/MacOS/RetroArch --verbose -L "/Users/mtnptrsn/Library/Application Support/RetroArch/cores/lutro_libretro.dylib" ./dist/explodelon.lutro
could not open destination file
failed to read file ./dist/explodelon/assets/black_imgfont.png
[1]    20319 segmentation fault  /Applications/RetroArch.app/Contents/MacOS/RetroArch --verbose -L
```