### PR TITLE
chore: add include_dir to tlconfig

### DIFF
--- a/tlconfig.lua
+++ b/tlconfig.lua
@@ -1,5 +1,6 @@
 return {
    global_env_def = "lutro",
+   include_dir = {"."},
    warning_error = {
       "branch",
       "debug",


### PR DESCRIPTION
Fixes this issue:

```bash
make package
mkdir -p dist
tl gen animation.tl -o dist/animation.lua
Error: could not predefine module 'lutro'
```

Our version `tl` versions weren't that far apart, @efredriksson , so a bit strange. Could perhaps be a mac vs. linux issue.