### PR TITLE
fix: decrease player hitbox so explosion hit needs to be more direct

### DIFF
--- a/src/explosions.tl
+++ b/src/explosions.tl
@@ -224,7 +224,7 @@ end
 function Explosion:collides_with(position: Point): boolean
     -- This should reflect on player hitbox, not same as
     -- hitbox stopping you from moving into wall.
-    local hitbox = hitboxes.new(position):shrink(2)
+    local hitbox = hitboxes.new(position):shrink(4)
 
     for _, tile in ipairs(self.tiles) do
         if hitbox:overlap(tile:hitbox()) then


### PR DESCRIPTION
Found it annoying how easy it was to get hit by explosions playing with insanity rule-set. This change also make it more similar to Saturn bomberman.

Saturn to the right for comparison:

![bomb-hitbox](https://github.com/user-attachments/assets/f23cf190-8678-41d0-bf90-a5682f6a715e)
